### PR TITLE
Remove check requester pays buckets

### DIFF
--- a/src/main/java/org/embulk/output/S3FileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/S3FileOutputPlugin.java
@@ -80,25 +80,24 @@ public class S3FileOutputPlugin implements FileOutputPlugin {
 
         private static AmazonS3Client newS3Client(PluginTask task) {
             AmazonS3Client client = null;
-            try {
-                if (task.getAccessKeyId().isPresent()) {
-                    BasicAWSCredentials basicAWSCredentials = new BasicAWSCredentials(
-                        task.getAccessKeyId().get(), task.getSecretAccessKey().get());
 
-                    ClientConfiguration config = new ClientConfiguration();
-                    // TODO: Support more configurations.
+            if (task.getAccessKeyId().isPresent()) {
+                BasicAWSCredentials basicAWSCredentials = new BasicAWSCredentials(
+                    task.getAccessKeyId().get(), task.getSecretAccessKey().get());
 
-                    client = new AmazonS3Client(basicAWSCredentials, config);
-                } else {
-                    if (System.getenv("AWS_ACCESS_KEY_ID") == null) {
-                        client = new AmazonS3Client(new EnvironmentVariableCredentialsProvider());
-                    } else { // IAM ROLE
-                        client = new AmazonS3Client();
-                    }
+                ClientConfiguration config = new ClientConfiguration();
+                // TODO: Support more configurations.
+
+                client = new AmazonS3Client(basicAWSCredentials, config);
+            } else {
+                if (System.getenv("AWS_ACCESS_KEY_ID") == null) {
+                    client = new AmazonS3Client(new EnvironmentVariableCredentialsProvider());
+                } else { // IAM ROLE
+                    client = new AmazonS3Client();
                 }
-                client.setEndpoint(task.getEndpoint());
-            } catch (Exception e) {
-                throw new RuntimeException("can't call S3 API. Please check your access_key_id / secret_access_key or s3_region configuration.", e);
+            }
+            if (task.getEndpoint().isPresent()) {
+                client.setEndpoint(task.getEndpoint().get());
             }
 
             return client;

--- a/src/main/java/org/embulk/output/S3FileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/S3FileOutputPlugin.java
@@ -96,12 +96,7 @@ public class S3FileOutputPlugin implements FileOutputPlugin {
                         client = new AmazonS3Client();
                     }
                 }
-
-                if (task.getEndpoint().isPresent()) {
-                    client.setEndpoint(task.getEndpoint().get());
-                }
-                
-                client.isRequesterPaysEnabled(task.getBucket()); // check s3 access.
+                client.setEndpoint(task.getEndpoint());
             } catch (Exception e) {
                 throw new RuntimeException("can't call S3 API. Please check your access_key_id / secret_access_key or s3_region configuration.", e);
             }


### PR DESCRIPTION
Hi @llibra .
Checking "Requester Pays Buckets" is too strict, I think.
"Requester Pays Buckets" on our S3 setting is not enabled, so we cannot use this plugin...

If you want to check accessing, I think it is better to use `client.doesBucketExist(task.getBucket());` instead of `client.isRequesterPaysEnabled(task.getBucket());`, how do you think?


ref.
- http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html
- http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3.html