### PR TITLE
Add `canned_acl` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,30 @@
 - **endpoint**: S3 endpoint login user name (string, optional)
 - **access_key_id**: AWS access key id. This parameter is required when your agent is not running on EC2 instance with an IAM Role. (string, defualt: null)
 - **secret_access_key**: AWS secret key. This parameter is required when your agent is not running on EC2 instance with an IAM Role. (string, defualt: null)
-- **tmp_path_prefix**: prefix of temporary files (string, defualt: 'embulk-output-s3-')
+- **tmp_path_prefix**: prefix of temporary files (string, default: 'embulk-output-s3-')
+- **canned_acl**: canned access control list for created objects ([enum](#CannedAccessControlList), default: null)
+
+### CannedAccessControlList
+you can choose one of the below list.
+
+- AuthenticatedRead
+  - Specifies the owner is granted Permission.FullControl and the GroupGrantee.AuthenticatedUsers group grantee is granted Permission.Read access.
+- AwsExecRead
+  - Specifies the owner is granted Permission.FullControl.
+- BucketOwnerFullControl
+  - Specifies the owner of the bucket, but not necessarily the same as the owner of the object, is granted Permission.FullControl.
+- BucketOwnerRead
+  - Specifies the owner of the bucket, but not necessarily the same as the owner of the object, is granted Permission.Read.
+- LogDeliveryWrite
+  - Specifies the owner is granted Permission.FullControl and the GroupGrantee.LogDelivery group grantee is granted Permission.Write access so that access logs can be delivered.
+- Private
+  - Specifies the owner is granted Permission.FullControl.
+- PublicRead
+  - Specifies the owner is granted Permission.FullControl and the GroupGrantee.AllUsers group grantee is granted Permission.Read access.
+- PublicReadWrite
+  - Specifies the owner is granted Permission.FullControl and the GroupGrantee.AllUsers group grantee is granted Permission.Read and Permission.Write access.
+
+cf. http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/model/CannedAccessControlList.html
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - **access_key_id**: AWS access key id. This parameter is required when your agent is not running on EC2 instance with an IAM Role. (string, defualt: null)
 - **secret_access_key**: AWS secret key. This parameter is required when your agent is not running on EC2 instance with an IAM Role. (string, defualt: null)
 - **tmp_path_prefix**: prefix of temporary files (string, default: 'embulk-output-s3-')
-- **canned_acl**: canned access control list for created objects ([enum](#CannedAccessControlList), default: null)
+- **canned_acl**: canned access control list for created objects ([enum](#cannedaccesscontrollist), default: null)
 
 ### CannedAccessControlList
 you can choose one of the below list.

--- a/README.md
+++ b/README.md
@@ -29,21 +29,13 @@
 you can choose one of the below list.
 
 - AuthenticatedRead
-  - Specifies the owner is granted Permission.FullControl and the GroupGrantee.AuthenticatedUsers group grantee is granted Permission.Read access.
 - AwsExecRead
-  - Specifies the owner is granted Permission.FullControl.
 - BucketOwnerFullControl
-  - Specifies the owner of the bucket, but not necessarily the same as the owner of the object, is granted Permission.FullControl.
 - BucketOwnerRead
-  - Specifies the owner of the bucket, but not necessarily the same as the owner of the object, is granted Permission.Read.
 - LogDeliveryWrite
-  - Specifies the owner is granted Permission.FullControl and the GroupGrantee.LogDelivery group grantee is granted Permission.Write access so that access logs can be delivered.
 - Private
-  - Specifies the owner is granted Permission.FullControl.
 - PublicRead
-  - Specifies the owner is granted Permission.FullControl and the GroupGrantee.AllUsers group grantee is granted Permission.Read access.
 - PublicReadWrite
-  - Specifies the owner is granted Permission.FullControl and the GroupGrantee.AllUsers group grantee is granted Permission.Read and Permission.Write access.
 
 cf. http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/model/CannedAccessControlList.html
 

--- a/src/main/java/org/embulk/output/S3FileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/S3FileOutputPlugin.java
@@ -8,6 +8,8 @@ import java.util.IllegalFormatException;
 import java.util.List;
 import java.util.Locale;
 
+import com.amazonaws.services.s3.model.AccessControlList;
+import com.google.common.collect.ImmutableMap;
 import org.embulk.config.TaskReport;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
@@ -28,11 +30,20 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.google.common.base.Optional;
 
 public class S3FileOutputPlugin
         implements FileOutputPlugin
 {
+    private static ImmutableMap<String, CannedAccessControlList> s3ObjectACL = getS3ObjectACL();
+    private static ImmutableMap<String, CannedAccessControlList> getS3ObjectACL() {
+        ImmutableMap.Builder<String, CannedAccessControlList> builder = ImmutableMap.builder();
+        builder.put("bucket_owner_full_control", CannedAccessControlList.BucketOwnerFullControl);
+        builder.put("bucket_owner_read", CannedAccessControlList.BucketOwnerRead);
+        return builder.build();
+    }
+
     public interface PluginTask
             extends Task
     {
@@ -155,6 +166,7 @@ public class S3FileOutputPlugin
         {
             PutObjectRequest request = new PutObjectRequest(bucket, key,
                     from.toFile());
+            request.withCannedAcl(CannedAccessControlList.BucketOwnerFullControl);
             client.putObject(request);
         }
 


### PR DESCRIPTION
@llibra 
I add `canned_acl` option for adding some priviledges to objects when putting data to not owned s3 bucket.
This p-r does not support all previledges. For example, this needs more customizable options if you want to use the `AuthenticatedRead` previledge. But I do not implement them because I do not need now.
If some users needs the options, I implement them.