### PR TITLE
[Issue 13] Embulk doesn't remove temporary files when job fails

### DIFF
--- a/src/main/java/org/embulk/output/S3FileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/S3FileOutputPlugin.java
@@ -245,6 +245,7 @@ public class S3FileOutputPlugin
                 current.write(buffer.array(), buffer.offset(), buffer.limit());
             }
             catch (IOException ex) {
+                deleteTempFile();
                 throw new RuntimeException(ex);
             }
             finally {


### PR DESCRIPTION
I create pull request about issue13 which I made.