### PR TITLE
Upgrade aws-java-sdk-s3 from 1.10.26 to 1.10.77

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ targetCompatibility = 1.7
 dependencies {
     compile  "org.embulk:embulk-core:0.8.1"
     provided "org.embulk:embulk-core:0.8.1"
-    compile  "com.amazonaws:aws-java-sdk-s3:1.10.26"
+    compile  "com.amazonaws:aws-java-sdk-s3:1.10.77"
     testCompile "junit:junit:4.+"
 }
 


### PR DESCRIPTION
@llibra 

Can you review this PR?

Related.

https://github.com/embulk/embulk-output-jdbc/pull/166
https://github.com/embulk/embulk-input-s3/pull/56

Best regards.
