### PR TITLE
Upgrade the Gradle plugin to v0.5.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "java"
     id "maven-publish"
     id "signing"
-    id "org.embulk.embulk-plugins" version "0.5.3"
+    id "org.embulk.embulk-plugins" version "0.5.5"
     id "checkstyle"
 }
 


### PR DESCRIPTION
Oops, I forgot that the latest Gradle plugin is v0.5.5, and v0.5.3 still had a bug in Gem push... :(

https://github.com/embulk/embulk-output-s3/actions/runs/3598254925/jobs/6060840043